### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ###Aims and Benefits
 
-The aim of **iRobotlegs** is the same as that of robotlegs; to make application development easier and more consistant accross projects, to encourage clear separtion of the application into Model, View, Controller and Service regions,to encourage and enable loose coupling between these regions through the use of dependency injection and Event/Notification based communication, and to lower the cognitive hit from appraising or maintaining understanding of a growing project through consistancy. As with most similar frameworks it is not always the best answer, and for trivial applications it will be overkill. A more concrete list of benefits are:
+The aim of **iRobotlegs** is the same as that of robotlegs; to make application development easier and more consistant across projects, to encourage clear separtion of the application into Model, View, Controller and Service regions,to encourage and enable loose coupling between these regions through the use of dependency injection and Event/Notification based communication, and to lower the cognitive hit from appraising or maintaining understanding of a growing project through consistancy. As with most similar frameworks it is not always the best answer, and for trivial applications it will be overkill. A more concrete list of benefits are:
 
 * Bannish Singletons.
 * Minimise dependencies between ViewControllers (Particularly important when writing reusable elements). You no longer need to pass data from viewControllers A-B-C-D just to get it to D.


### PR DESCRIPTION
@Undistraction, I've corrected a typographical error in the documentation of the [iRobotlegs](https://github.com/Undistraction/iRobotlegs) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.